### PR TITLE
Fix: tailwind extend with prefix not exporting classNames

### DIFF
--- a/packages/frontend/src/components/connect-wallet/index.tsx
+++ b/packages/frontend/src/components/connect-wallet/index.tsx
@@ -66,13 +66,13 @@ export const ConnectWallet = () => {
                                     <Logo className="w-4 h-4" />
                                 </div>
                             ) : (
-                                <div className="w-8 h-8 mr-2 rounded-lg bg-black" />
+                                <div className="w-8 h-8 mr-2 bg-black rounded-lg" />
                             )}
                             <div className="flex flex-col mr-4">
-                                <span className="text-black font-mono text-2xs">
+                                <span className="font-mono text-black text-xxs">
                                     {t("connect.wallet.network")}
                                 </span>
-                                <span className="text-black font-mono text-sm capitalize">
+                                <span className="font-mono text-sm text-black capitalize">
                                     {chainName}
                                 </span>
                             </div>

--- a/packages/frontend/src/components/ui/campaign-card/index.tsx
+++ b/packages/frontend/src/components/ui/campaign-card/index.tsx
@@ -40,12 +40,11 @@ export const CampaignCard = ({
                     <TextMono color={correctColor(color)} weight="medium" caps>
                         {title}
                     </TextMono>
-
                     {isHolding && (
                         <div className="flex items-center justify-center px-2 py-1 border rounded bg-carrot-green">
                             <TextMono
                                 weight="medium"
-                                size="2xs"
+                                size="xxs"
                                 caps
                                 color="black"
                             >

--- a/packages/ui/src/text-mono/index.stories.tsx
+++ b/packages/ui/src/text-mono/index.stories.tsx
@@ -3,14 +3,14 @@ import { ComponentMeta, ComponentStory } from "@storybook/react";
 
 import { TextMono } from ".";
 
-const sizes: ["2xl", "xl", "lg", "md", "sm", "xs", "2xs"] = [
+const sizes: ["2xl", "xl", "lg", "md", "sm", "xs", "xxs"] = [
     "2xl",
     "xl",
     "lg",
     "md",
     "sm",
     "xs",
-    "2xs",
+    "xxs",
 ];
 
 export default {

--- a/packages/ui/src/text-mono/index.tsx
+++ b/packages/ui/src/text-mono/index.tsx
@@ -14,7 +14,7 @@ const textStyles = cva(["font-mono dark:text-white"], {
             black: "cui-text-black",
         },
         size: {
-            "2xs": ["cui-text-2xs"],
+            xxs: ["cui-text-xxs"],
             xs: ["cui-text-xs"],
             sm: ["cui-text-sm"],
             md: ["cui-text-md"],
@@ -29,7 +29,7 @@ const textStyles = cva(["font-mono dark:text-white"], {
 });
 
 export interface TextMonoProps {
-    size?: "2xs" | "xs" | "sm" | "md" | "lg" | "xl" | "2xl";
+    size?: "xxs" | "xs" | "sm" | "md" | "lg" | "xl" | "2xl";
     color?: "white" | "black";
     weight?: "medium";
     caps?: boolean;

--- a/packages/ui/tailwind.config.js
+++ b/packages/ui/tailwind.config.js
@@ -6,7 +6,7 @@ module.exports = {
     theme: {
         extend: {
             fontSize: {
-                "2xs": "10px",
+                xxs: "10px",
             },
         },
     },

--- a/packages/ui/tailwind.preset.js
+++ b/packages/ui/tailwind.preset.js
@@ -40,7 +40,7 @@ module.exports = {
         },
         extend: {
             fontSize: {
-                "2xs": "10px",
+                xxs: "10px",
             },
             backgroundImage: {
                 "square-pattern-white-bg":


### PR DESCRIPTION
Seems like using tailwind presets with prefix does not pick tailwind theme extend config. 

Found this issue, [Conflict between custom config and preset with prefix](https://github.com/tailwindlabs/tailwindcss/discussions/6126), that seems similar to ours on tailwind discussion but has no answer.

This fix is a workaround that issue.

_eg. TextMono with size xxs_

<img width="1180" alt="image" src="https://user-images.githubusercontent.com/5664434/210443893-5ed43631-c656-4986-a44e-47f0cfd778c1.png">
