### PR TITLE
fix: mobile menu icons

### DIFF
--- a/packages/frontend/src/assets/menu.svg
+++ b/packages/frontend/src/assets/menu.svg
@@ -5,7 +5,7 @@
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
 >
-    <rect x="4.5" y="7.14258" width="27" height="2" fill={color} />
-    <rect x="4.5" y="26.8574" width="27" height="2" fill={color} />
-    <rect x="4.5" y="17" width="27" height="2" fill={color} />
+    <rect x="4.5" y="7.14258" width="27" height="2" fill="black" />
+    <rect x="4.5" y="26.8574" width="27" height="2" fill="black" />
+    <rect x="4.5" y="17" width="27" height="2" fill="black" />
 </svg>

--- a/packages/frontend/src/assets/x.svg
+++ b/packages/frontend/src/assets/x.svg
@@ -1,16 +1,4 @@
-<svg
-    width="20"
-    height="20"
-    viewBox="0 0 20 20"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
->
-    <path
-        d="M1.51465 1.50073L18.4852 18.4713"
-        strokeWidth="1.5"
-    />
-    <path
-        d="M1.51465 18.4995L18.4852 1.52895"
-        strokeWidth="1.5"
-    />
+<svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M8.4541 8.43823L27.546 27.5301" stroke="black" strokeWidth="1.6875"/>
+    <path d="M8.4541 27.562L27.546 8.47013" stroke="black" strokeWidth="1.6875"/>
 </svg>

--- a/packages/frontend/src/components/ui/navbar/index.tsx
+++ b/packages/frontend/src/components/ui/navbar/index.tsx
@@ -2,8 +2,8 @@ import React, { useEffect, useState } from "react";
 import { NavLink } from "react-router-dom";
 import { Logo } from "@carrot-kpi/ui";
 import { cva } from "class-variance-authority";
-import { ReactComponent as CloseMenuIcon } from "../../../assets/x.svg";
-import { ReactComponent as HamburgerMenuIcon } from "../../../assets/menu.svg";
+import { ReactComponent as CloseIcon } from "../../../assets/x.svg";
+import { ReactComponent as MenuIcon } from "../../../assets/menu.svg";
 import { GridPatternBg } from "../grid-pattern-bg";
 import { ConnectWallet } from "../../connect-wallet";
 
@@ -112,7 +112,7 @@ export const Navbar = ({ bgColor, links }: NavbarProps) => {
                     <ConnectWallet />
                 </div>
                 <div className="md:hidden" onClick={() => setOpen(!isOpen)}>
-                    {isOpen ? <CloseMenuIcon /> : <HamburgerMenuIcon />}
+                    {isOpen ? <CloseIcon /> : <MenuIcon />}
                 </div>
             </div>
         </div>


### PR DESCRIPTION

<img width="298" alt="image" src="https://user-images.githubusercontent.com/5664434/210607029-2234af9b-4027-4b3d-a8e7-ccf0716c11b2.png">

<img width="422" alt="image" src="https://user-images.githubusercontent.com/5664434/210606230-37663532-190a-42ba-8ff1-d3d63a734800.png">
<img width="450" alt="image" src="https://user-images.githubusercontent.com/5664434/210606316-11dbd3a9-dd94-4554-9eab-ca84aec8386b.png">

- Menu icons weren't picking color.
- the menu on mobile would bump a little when toggled, the X icon svg was not the same size as the hamburger icon, this PR also fixes that.

