### PR TITLE
replace fragment with div

### DIFF
--- a/packages/ui/src/input/commons/index.tsx
+++ b/packages/ui/src/input/commons/index.tsx
@@ -53,7 +53,7 @@ export const LabelWrapper = ({
     className,
     children,
 }: LabelWrapperProps): ReactElement => (
-    <>
+    <div>
         {!!label && (
             <label
                 className={`cui-block cui-w-fit cui-mb-2 ${className}`}
@@ -65,5 +65,5 @@ export const LabelWrapper = ({
             </label>
         )}
         {children}
-    </>
+    </div>
 );


### PR DESCRIPTION
Using a fragment as the root element of the `LabelWrapper` that wraps the input component and the label, causes the `<label />` and the `<input />` to be at the root level of a parent container, such as a `div`. This leads to potentially annoying behaviors when there are multiple inputs as children of a `flex` container and they need to be spaced by a certain amount of px (`gap-x`), because then the `label` and the `input` tags are both affected by the spacing, leading to undesired results.

With the `</>` as wrapper:
![image](https://user-images.githubusercontent.com/9011637/211839763-18e06f0a-cffb-49c7-97aa-1027b5100b70.png)

WIth the `<div/>` as wrapper:
![image](https://user-images.githubusercontent.com/9011637/211840085-73dc33d4-e63b-4c35-9511-6292b33a550e.png)

