### PR TITLE
remove css classes from the markdown html content

### DIFF
--- a/packages/ui/src/input/markdown/index.tsx
+++ b/packages/ui/src/input/markdown/index.tsx
@@ -35,7 +35,7 @@ export const MarkdownInput = ({
         ],
         editorProps: {
             attributes: {
-                class: "cui-prose cui-prose-sm focus:cui-outline-none cui-font-mono cui-h-full dark:cui-text-white prose-h1:dark:cui-text-white prose-h2:dark:cui-text-white prose-strong:dark:cui-text-white prose-blockquote:dark:cui-text-white",
+                class: "cui-prose cui-prose-sm focus:cui-outline-none cui-font-mono cui-h-full dark:cui-prose-invert prose-pre:dark:cui-bg-gray-700",
             },
         },
         onUpdate: ({ editor }) => {


### PR DESCRIPTION
Apply the custom classes to the editor content using the `prose-*` selector coming from the `@tailwindcss/typography` plugin; this way the classes are not applied directly to the HTML elements of the editor content.