### PR TITLE
feat: add full width support to Select component and apply it on camp…

### DIFF
--- a/packages/frontend/src/pages/campaigns/all-campaigns-section/campaigns-top-nav/index.tsx
+++ b/packages/frontend/src/pages/campaigns/all-campaigns-section/campaigns-top-nav/index.tsx
@@ -18,8 +18,8 @@ export const CampaignsTopNav = ({
     return (
         <div className="flex px-6 py-6 bg-white border-t border-b border-gray-400 md:px-12 dark:bg-black">
             <div className="flex flex-col items-center justify-between w-full md:flex-row">
-                <div className="flex flex-col w-full gap-5 md:flex-row">
-                    <div className="flex gap-5 mb-4 md:mb-0">
+                <div className="flex flex-col w-full gap-5 mb-5 md:mb-0 md:flex-row">
+                    <div className="flex gap-5">
                         <div
                             className="p-3 border rounded-xl "
                             onClick={toggleFilters}
@@ -27,6 +27,7 @@ export const CampaignsTopNav = ({
                             FY
                         </div>
                         <Select
+                            fullWidth
                             label=""
                             id="campaigns-filter-order"
                             onChange={setCampaignsOrder}
@@ -44,8 +45,9 @@ export const CampaignsTopNav = ({
                             value={campaignsOrder}
                         />
                     </div>
-                    <div className="flex flex-row-reverse gap-5 mb-4 md:flex-row md:mb-0">
+                    <div className="flex flex-row-reverse gap-5 md:flex-row">
                         <Select
+                            fullWidth
                             label=""
                             id="campaigns-filter-state"
                             onChange={setCampaignState}

--- a/packages/ui/src/input/commons/index.tsx
+++ b/packages/ui/src/input/commons/index.tsx
@@ -26,6 +26,9 @@ export const inputStyles = cva(
                 xl: ["cui-text-xl"],
                 xxl: ["cui-text-xxl"],
             },
+            fullWidth: {
+                true: ["cui-w-full"],
+            },
             border: {
                 true: [
                     "cui-border cui-border-black dark:cui-border-white focus:cui-border-orange dark:focus:cui-border-orange cui-bg-transparent",
@@ -36,6 +39,7 @@ export const inputStyles = cva(
         defaultVariants: {
             size: "md",
             border: true,
+            fullWidth: false,
         },
     }
 );

--- a/packages/ui/src/input/select/index.tsx
+++ b/packages/ui/src/input/select/index.tsx
@@ -44,6 +44,29 @@ const optionStyles = cva(
     }
 );
 
+const selectRootStyles = cva([""], {
+    variants: {
+        fullWidth: {
+            true: "w-full",
+        },
+    },
+    defaultVariants: {
+        fullWidth: false,
+    },
+});
+
+const selectAnchorStyles = cva(["cui-select-wrapper", "cui-relative"], {
+    variants: {
+        fullWidth: {
+            true: "cui-w-full",
+            false: "cui-w-fit",
+        },
+    },
+    defaultVariants: {
+        fullWidth: false,
+    },
+});
+
 export interface SelectOption {
     label: string;
     value: ValueType;
@@ -53,6 +76,7 @@ export interface SelectOption {
 export type ValueType = string | number;
 
 export type SelectProps<O extends SelectOption = SelectOption> = {
+    fullWidth?: boolean;
     options: O[];
     value: O | null;
     onChange: (value: O) => void;
@@ -69,6 +93,7 @@ export const Select = <O extends SelectOption>({
     onChange,
     className,
     renderOption,
+    fullWidth,
     ...rest
 }: SelectProps<O>): ReactElement => {
     const [anchorElement, setAnchorElement] = useState<HTMLDivElement | null>(
@@ -122,10 +147,10 @@ export const Select = <O extends SelectOption>({
     );
 
     return (
-        <div className={className}>
+        <div className={selectRootStyles({ className, fullWidth })}>
             <LabelWrapper id={id} label={label}>
                 <div
-                    className="cui-select-wrapper cui-relative cui-w-fit"
+                    className={selectAnchorStyles({ fullWidth })}
                     ref={setAnchorElement}
                 >
                     <input
@@ -138,6 +163,7 @@ export const Select = <O extends SelectOption>({
                         className={inputStyles({
                             size,
                             border,
+                            fullWidth,
                             className:
                                 "cui-select-input cui-w-fit cui-cursor-pointer",
                         })}


### PR DESCRIPTION
closes #58 

### Summary

Add full-width to Select component and apply it on campaigns top nav.

<img width="483" alt="image" src="https://user-images.githubusercontent.com/5664434/213029411-4791d530-7774-47a9-ac72-db0ba17ec5d1.png">

### Storybook

<img width="497" alt="image" src="https://user-images.githubusercontent.com/5664434/213029571-46fc8394-9b52-4647-865e-19977aea2620.png">
<img width="1098" alt="image" src="https://user-images.githubusercontent.com/5664434/213029601-97cec149-afe1-45d8-ae30-b263c7ea39a8.png">

