### PR TITLE
fix: search icon should match wrapper color

### DIFF
--- a/packages/ui/src/assets/search-icon.svg
+++ b/packages/ui/src/assets/search-icon.svg
@@ -7,13 +7,13 @@
 >
   <path
       d="M14.4121 14.9131L20 20.501"
-      stroke="black"
+      stroke="currentColor"
       strokeLinecap="round"
   />
   <path
       fillRule="evenodd"
       clipRule="evenodd"
       d="M10 16.501C13.3137 16.501 16 13.8147 16 10.501C16 7.18727 13.3137 4.50098 10 4.50098C6.68629 4.50098 4 7.18727 4 10.501C4 13.8147 6.68629 16.501 10 16.501Z"
-      stroke="black"
+      stroke="currentColor"
   />
 </svg>

--- a/packages/ui/src/input/search/index.tsx
+++ b/packages/ui/src/input/search/index.tsx
@@ -28,7 +28,7 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
             >
                 <div
                     className={cx(
-                        "cui-absolute cui-top-3 cui-left-3",
+                        "cui-absolute cui-top-3 cui-left-3 dark:cui-text-white",
                         className?.iconWrapper
                     )}
                 >


### PR DESCRIPTION
Search icon now appears correctly on dark mode.

<img width="407" alt="image" src="https://user-images.githubusercontent.com/5664434/217151116-65c554d7-9391-4621-aee9-1c09c637a14d.png">
